### PR TITLE
inline CSS tweak to make teaser a little friendlier

### DIFF
--- a/maproulette/templates/teaser.html
+++ b/maproulette/templates/teaser.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
 <body>
-<div style='font-size: 10vmax; top: 5vmax; text-align: center; '>{{ config.TEASER_TEXT }}</div>
+<div style='font-size: 4vmax; top: 5vmax; text-align: center; margin: 0 auto; width: 70%;'>{{ config.TEASER_TEXT }}</div>
 </body>
 {% endblock %}


### PR DESCRIPTION
Just a quick tweak that makes the teaser message ("Everything is fixed", etc.) smaller and less intimidating.

(the newline at the end of the file is a Vim artifact)
