### PR TITLE
load_fixtures.py: Fix loading of the config

### DIFF
--- a/bin/load_fixtures.py
+++ b/bin/load_fixtures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from maproulette import app, config
+from maproulette import app
 from maproulette.models import db, Challenge, Task, TaskGeometry, Action
 from shapely.geometry import Point, LineString, box
 import uuid
@@ -48,9 +48,6 @@ of withering injustice. It came as a joyous daybreak to end the
 long night of captivity."""
 
 point = Point(0.0, 0.0)
-
-# This determines which database is going to be populated
-app.config.from_object(config.DevelopmentConfig)
 
 # delete old tasks and challenges
 db.session.query(TaskGeometry).delete()


### PR DESCRIPTION
The loading of the config was broken. Remove it because the config is
already loaded in maproulette/**init**.py
