### PR TITLE
fixing database permission problem and adding flask manage task to fabric

### DIFF
--- a/fabric_templates/config
+++ b/fabric_templates/config
@@ -12,7 +12,7 @@ SECRET_KEY = 'een ei is geen ei twee ei is een half ei'
 {% endif %}
 
 # The database connection
-SQLALCHEMY_DATABASE_URI = "postgresql://osm:osm@localhost/{{db}}"
+SQLALCHEMY_DATABASE_URI = "postgresql://osm@localhost/{{db}}"
 
 # show a teaser page instead of the real thing
 TEASER = False


### PR DESCRIPTION
This pull request:
- Fixes #211 
- Adds a flask_manage(instance, command) function which is now used to issue the initial model materialization. Can also be used to create the test data by manually issuing `fab flask_manage:instancename,command=create_testdata`.
