### PR TITLE
Resolving #239 and #238

### DIFF
--- a/maproulette/static/css/style.css
+++ b/maproulette/static/css/style.css
@@ -15,7 +15,7 @@ em {
 }
 
 /* the main MapRoulette control panel */
-div.controlpanel {
+div#controlpanel {
     border: 1px solid #aaa;
     z-index:15;
     position:absolute;

--- a/maproulette/templates/index.html
+++ b/maproulette/templates/index.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block body %}
 <body onload="init('map')">
-<div class="controlpanel">
+<div id="mr">
+<div id="controlpanel">
     <div class="title">OpenStreetMap <em>MapRoulette</em></div>
     <div id="user">
         {%- if session.get('osm_token') -%}
@@ -30,6 +31,7 @@
 <div class="notifications"></div>
 <div id="dialog"></div>
 <div id="map"></div>
+</div>
 </body>
 {% endblock %}
 


### PR DESCRIPTION
This wraps maproulette inside an id (which will make life easier for the react components in the future) and also makes controlpanel an id'd div.
