### PR TITLE
user selection of preferred editing area + required backend changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ deploy_templates/*
 deploy_files/*
 examples/responses.json
 maproulette/static/js/maproulette.js
+maproulette/static/js/.module-cache/

--- a/maproulette/static/css/style.css
+++ b/maproulette/static/css/style.css
@@ -152,7 +152,7 @@ div#challenge_blurb {
 }
 
 /* the little stats section */
-div#stats {
+div.smallmsg {
     font-size: x-small;
     color: rgb(100,100,100);
 }
@@ -207,4 +207,24 @@ td.hidden {
 
 table.stats {
     padding: 4px;
+}
+
+/* react transitions */
+
+.dialog-enter {
+  opacity: 0.01;
+  transition: opacity .5s ease-in;
+}
+
+.dialog-enter.dialog-enter-active {
+  opacity: 1;
+}
+
+.dialog-leave {
+  opacity: 1;
+  transition: opacity .5s ease-in;
+}
+
+.dialog-leave.example-leave-active {
+  opacity: 0.01;
 }

--- a/maproulette/static/index.html
+++ b/maproulette/static/index.html
@@ -1,0 +1,1 @@
+<html><head><title>MapRoulette Maintenance></title></head><body><h1>MapRoulette is undergoing a bit of maintenance. Please check back soon!</body></html>

--- a/maproulette/templates/index.html
+++ b/maproulette/templates/index.html
@@ -21,7 +21,10 @@
         <div class="button tiny" onClick='location.href="{{ url_for("challenge_stats") }}";'>Challenge statistics</div>
         <!--<div class="button tiny" id="preferences" onClick='MRManager.userPreferences()'>MapRoulette Options</div>-->
     </div>
-    <div id="stats">This challenge has <span id="challenge_total">N/A</span> tasks, and we still need to fix <span id="challenge_unfixed">N/A</span> of them.</div>
+    <div class="smallmsg" id="stats">This challenge has <span id="challenge_total">N/A</span> tasks, and we still need to fix <span id="challenge_unfixed">N/A</span> of them.</div>
+    <div class="smallmsg" id="msg_editarea" style="display:none">
+        You are working within the area you selected. The numbers above are for that area, not the entire challenge.
+    </div>
     <hr />
     <div class="button" onClick='MRManager.nextTask("falsepositive")'>THIS IS NOT AN ERROR <span class=key>q</span></div>
     <div class="button" onClick='MRManager.nextTask("skipped")'>I'M NOT SURE / SKIP <span class=key>w</span></div>

--- a/migrations/versions/3115f24a7604_.py
+++ b/migrations/versions/3115f24a7604_.py
@@ -1,0 +1,26 @@
+"""adding location column to tasks table
+
+Revision ID: 3115f24a7604
+Revises: 38fe795129a0
+Create Date: 2014-05-04 14:02:19.755081
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3115f24a7604'
+down_revision = '38fe795129a0'
+
+from alembic import op
+
+
+def upgrade():
+    # there is no way to tell alembic to add a geometry column the right way?
+    op.execute(
+        "SELECT AddGeometryColumn('tasks', 'location', 4326, 'POINT', 2)")
+    # there is no way to tell alembic that we want a GiST type index?
+    op.execute("CREATE INDEX idx_tasks_location ON tasks USING GIST(location)")
+
+
+def downgrade():
+    op.drop_index('idx_tasks_location', 'tasks')
+    op.drop_column('tasks', 'location')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask>=0.10.1
-Flask-RESTful>=0.2.0
+# Flask-RESTful>=0.2.0
+-e git://github.com/twilio/flask-restful.git#egg=flask-restful
 Flask-KVSession>=0.4
 Flask-OAuthlib>=0.4.2
 Flask-SQLAlchemy>=1.0


### PR DESCRIPTION
This pull request focuses on adding preferred local area support for MapRoulette. It works like this. A new button appears at the top of the challenge selection dialog:

![screenshot 2014-05-05 13 49 25](https://cloud.githubusercontent.com/assets/120452/2932404/3e9a9fd8-d7b0-11e3-8d02-51b50aa0baba.png)

After clicking this, the user can click on the map to select the center of their editing area. A notification pops up to guide them:

![screenshot 2014-05-05 14 05 05](https://cloud.githubusercontent.com/assets/120452/2932409/65d5a67e-d7b0-11e3-96d5-78659c4707bd.png)

After this, the challenge selection will be filtered for this area.

Also, statistics in the sidebar are back. 

The changes are mostly client side, but a notable change in the back end is the addition of a location field in the Task model. This field holds a location hint for each task (a point), based on the geometries.  This field will be populated automatically for new tasks as geometries are loaded / changed, but the field needs to be populated for existing tasks when upgrading an existing deployment. There is a new function in the manager script for this, so this is as simple as 

```
python manage.py populate_task_loacation
```

This can take a little time, I tested it on a dev instance with about 100K tasks on it and that took something like 45 minutes.
