### PR TITLE
update requirements to Flask-Admin 1.0.8 because 1.0.7 breaks when WTFor...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ six>=1.5.2
 nose>=1.3.0
 Markdown==2.3.1
 iso8601==0.1.10
-Flask-Admin==1.0.7
+Flask-Admin==1.0.8
 requests==2.2.1
 Fabric==1.7.0


### PR DESCRIPTION
...ms gets updated

This fixes #260.
