### PR TITLE
Fixes Mapquest Nominatim API call

### DIFF
--- a/jsx/maproulette.js
+++ b/jsx/maproulette.js
@@ -697,7 +697,7 @@ var MRManager = (function () {
         };
 
         var displayAdminArea = function () {
-            var mqurl = 'http://open.mapquestapi.com/nominatim/v1/reverse?format=json&lat=' + map.getCenter().lat + ' &lon=' + map.getCenter().lng;
+            var mqurl = 'http://open.mapquestapi.com/nominatim/v1/reverse.php?format=json&lat=' + map.getCenter().lat + '&lon=' + map.getCenter().lng;
             $.ajax({
                 url: mqurl,
                 success: function (data) {


### PR DESCRIPTION
Right now Maproulette says "We are somewhere on earth..." at the bottom of each task. @Ahlzen and I decided to take on fixing it during today's mapathon. Can you please fully test as we haven't stood up a complete separate Maproulette instance?

Remove a space in the nominatim API URL and add '.php' to the end
of the root endpoint.

Following MQ docs: http://open.mapquestapi.com/nominatim/

Fix made with Lars Ahlzen at #mapathon summer 2015.