### PR TITLE
Batch Uploads 

### DIFF
--- a/maproulette/helpers.py
+++ b/maproulette/helpers.py
@@ -65,11 +65,20 @@ def challenge_exists(challenge_slug):
 def get_task_or_404(challenge_slug, task_identifier):
     """Return a task based on its challenge and task identifier"""
 
+    t = get_task_or_none(challenge_slug, task_identifier)
+    if t is None:
+        abort(404)
+    return t
+
+
+def get_task_or_none(challenge_slug, task_identifier):
+    """Return a task based on it's challenge and task identifier or none if not found"""
+
     t = Task.query.filter(
         Task.challenge_slug == challenge_slug).filter(
         Task.identifier == task_identifier).first()
     if not t:
-        abort(404)
+        return None
     return t
 
 

--- a/maproulette/templates/base.html
+++ b/maproulette/templates/base.html
@@ -26,6 +26,7 @@
     {% endblock %}
     {% block piwik %}
     <!-- Piwik -->
+    <!--
     <script type="text/javascript">
       var _paq = _paq || [];
       _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
@@ -41,6 +42,7 @@
       })();
     </script>
     <noscript><p><img src="http://198.58.115.35/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
+    -->
     <!-- End Piwik Code -->
     {% endblock %}
 </head>


### PR DESCRIPTION
This is a minor change to handle batch uploads a little easier, for larger uploads. Basically it works like this:

POST
This will run through the batch and create new entries, but for already existing entries it will simply log a message stating that it will skip that entry. This differs in behavior from the previous version which would throw a 404 as soon as it found an already existing entry in the uploaded batch.

PUT
This will run through the batch and create new entries again, but for already existing entries it will update the entries as opposed to the post which will skip them. Which again differs from the previous versions behavior which would throw a 404 if the entry did not exist. 

The benefits I believe in handling it this way is that if you are uploading large batches of challenges, you don't have to check each entry prior to including it in the batch. If you have 1000 tasks you want to include as part of an already existing challenge, if you want to write you code safely you would then have to first send an HTTP request to the MapRoulette server to check if it exists or not. If you don't you have a chance that the entire batch could be rejected. Alternatively you could keep a local record of the tasks, however it could always be modified out of your process. This way the MapRoulette server handles all that work for the user, make the code calling into the server much simpler.

Let me know if you need further details, or have any other questions about the change.